### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A TypeScript implementation of a Model Context Protocol (MCP) server for Trello integration, providing tools for AI assistants to interact with Trello boards, lists, and cards.
 
+<a href="https://glama.ai/mcp/servers/zekev8gy7i"><img width="380" height="200" src="https://glama.ai/mcp/servers/zekev8gy7i/badge" alt="Trello Server MCP server" /></a>
+
 ## Features
 
 - Full Trello API integration through MCP tools


### PR DESCRIPTION
This PR adds a badge for the [Trello MCP Server](https://glama.ai/mcp/servers/zekev8gy7i) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/zekev8gy7i"><img width="380" height="200" src="https://glama.ai/mcp/servers/zekev8gy7i/badge" alt="Trello Server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.